### PR TITLE
Fix: add unique key for constraint fk_category, to make MySQL 8+ happy

### DIFF
--- a/sql/11-13-2026_Example_Data.sql
+++ b/sql/11-13-2026_Example_Data.sql
@@ -93,7 +93,8 @@ DROP TABLE IF EXISTS `paragon_config_category`;
 CREATE TABLE `paragon_config_category` (
   `id` int NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL,
-  PRIMARY KEY (`id`,`name`)
+  PRIMARY KEY (`id`,`name`),
+  UNIQUE (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 /*Data for the table `paragon_config_category` */


### PR DESCRIPTION
I don't really understand the why and how of this, but trying to import the example data SQL file gives this error on MySQL 9.4:
```
Error Code: 6125
Failed to add the foreign key constraint. Missing unique key for constraint 'fk_category' in the referenced table 'paragon_config_category'
```

Googling around gave me [this](https://stackoverflow.com/questions/11966420/error-there-is-no-unique-constraint-matching-given-keys-for-referenced-table-b), which isn't exactly the same issue but it works.