### PR TITLE
Change LEVEL_LINKED_TO_ACCOUNT check to string comparison

### DIFF
--- a/serverside/paragon/paragon_class.lua
+++ b/serverside/paragon/paragon_class.lua
@@ -95,7 +95,7 @@ end
 function Paragon:new(player_guid, account_id)
     self.guid = player_guid
 
-    if (Config:GetByField("LEVEL_LINKED_TO_ACCOUNT") == 1) then
+    if (Config:GetByField("LEVEL_LINKED_TO_ACCOUNT") == "1") then
         self.account = account_id
     end
 
@@ -124,7 +124,7 @@ end
 --- @param callback Function to invoke after loading (receives guid, self)
 ---
 function Paragon:Load(callback)
-    if (Config:GetByField("LEVEL_LINKED_TO_ACCOUNT") == 1) then
+    if (Config:GetByField("LEVEL_LINKED_TO_ACCOUNT") == "1") then
         -- Account-linked mode: load from account_paragon
         Repository:GetParagonByAccountId(self.account, function(data)
             if data and data.level then
@@ -156,7 +156,7 @@ end
 --- - If disabled (0): Saves to character_paragon table using character guid
 ---
 function Paragon:Save()
-    if (Config:GetByField("LEVEL_LINKED_TO_ACCOUNT") == 1) then
+    if (Config:GetByField("LEVEL_LINKED_TO_ACCOUNT") == "1") then
         -- Account-linked mode: save to account_paragon
         Repository:SaveParagonByAccount(self.account, self.level, self.exp.current)
     else


### PR DESCRIPTION
Possible fix for account-linked paragon mode not working

I was having an issue where account-linked paragon wasn't working even though `LEVEL_LINKED_TO_ACCOUNT` was set to `1` in the config. 

Turns out the config table stores values as varchar, so `Config:GetByField("LEVEL_LINKED_TO_ACCOUNT")` returns the string `"1"`, not the number `1`. In Lua, comparing `"1" == 1` returns false, so the account-linked check was always failing.

Changed the three comparisons from `== 1` to `== "1"` (string comparison instead of number):
- Constructor: Sets `self.account` when account-linked mode is enabled
- Load(): Routes to `account_paragon` table instead of `character_paragon`
- Save(): Saves to `account_paragon` table instead of `character_paragon`

This fixed it for me - account-linked paragon now works as expected.

#20 might be related